### PR TITLE
feat: expand homepage content and layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ node_modules/
 dist/
 .pnpm-store/
 .env.local
+*.tsbuildinfo
+tailwind.config.js
+tailwind.config.d.ts
+vite.config.js
+vite.config.d.ts
 
 # Logs
 npm-debug.log*

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Source+Sans+3:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Red Clay Field Guide</title>
   </head>
   <body class="bg-brand-cream text-brand-charcoal">

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,100 +1,142 @@
 import { motion } from 'framer-motion';
+import FeaturedStories from '../features/home/FeaturedStories';
+import CategoryShowcase from '../features/home/CategoryShowcase';
+import NewsletterSignup from '../features/home/NewsletterSignup';
+import SponsorSpotlight from '../features/home/SponsorSpotlight';
+import { featuredStories, homepageSections, sponsorSpotlight } from '../lib/homepageData';
 
 const heroVariants = {
   hidden: { opacity: 0, y: 16 },
   visible: { opacity: 1, y: 0 }
 };
 
+const navLinks = [
+  { label: 'Stories', href: '#stories' },
+  { label: 'Food', href: '#food' },
+  { label: 'Travel', href: '#travel' },
+  { label: 'Entertainment', href: '#entertainment' },
+  { label: 'Services', href: '#services' }
+];
+
+const heroHighlights = [
+  'Weekend itineraries curated by Shane & Vicki',
+  'Local restaurants, trails, makers & events',
+  'Subscriber-only sponsor perks & giveaways'
+];
+
 const App = () => {
   return (
     <div className="min-h-screen bg-brand-cream text-brand-charcoal">
-      <header className="border-b border-brand-charcoal/10 bg-white/80 backdrop-blur">
+      <header className="sticky top-0 z-40 border-b border-brand-charcoal/10 bg-white/80 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
-          <span className="font-display text-xl font-semibold tracking-wide text-brand-red">
+          <a className="font-display text-xl font-semibold uppercase tracking-[0.3em] text-brand-red" href="#stories">
             Red Clay Field Guide
-          </span>
-          <nav className="hidden gap-6 text-sm font-medium sm:flex">
-            <a className="transition hover:text-brand-red" href="#">
-              Food
-            </a>
-            <a className="transition hover:text-brand-red" href="#">
-              Travel
-            </a>
-            <a className="transition hover:text-brand-red" href="#">
-              Entertainment
-            </a>
-            <a className="transition hover:text-brand-red" href="#">
-              Services
-            </a>
+          </a>
+          <nav className="hidden items-center gap-6 text-xs font-semibold uppercase tracking-[0.3em] text-brand-charcoal/70 lg:flex">
+            {navLinks.map((link) => (
+              <a key={link.href} className="transition hover:text-brand-red" href={link.href}>
+                {link.label}
+              </a>
+            ))}
           </nav>
+          <a
+            className="hidden rounded-full bg-brand-red px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-md shadow-brand-red/30 transition hover:-translate-y-0.5 hover:shadow-lg lg:inline-flex"
+            href="#newsletter"
+          >
+            Subscribe
+          </a>
         </div>
       </header>
       <main>
-        <section className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-16 sm:flex-row sm:items-center">
+        <section
+          className="relative mx-auto flex max-w-6xl flex-col gap-10 px-4 pb-12 pt-20 sm:flex-row sm:items-center"
+          id="stories"
+        >
           <motion.div
             initial="hidden"
             animate="visible"
-            transition={{ duration: 0.6, ease: 'easeOut' }}
+            transition={{ duration: 0.65, ease: 'easeOut' }}
             variants={heroVariants}
-            className="max-w-xl"
+            className="max-w-xl space-y-8"
           >
-            <p className="mb-3 font-semibold uppercase tracking-[0.2em] text-brand-red">
-              Explore Northeast Georgia
-            </p>
-            <h1 className="font-display text-4xl font-semibold leading-tight text-brand-charcoal sm:text-5xl">
-              Stories from the foothills, curated by Shane & Vicki.
-            </h1>
-            <p className="mt-6 text-lg text-brand-charcoal/80">
-              The Red Clay Field Guide celebrates the food, trails, hidden gems, and people that make Northeast Georgia special.
-              Follow along as we share weekend itineraries, seasonal guides, and local favorites.
-            </p>
-            <div className="mt-8 flex flex-wrap items-center gap-4">
+            <div className="space-y-4">
+              <p className="font-semibold uppercase tracking-[0.3em] text-brand-red">Explore Northeast Georgia</p>
+              <h1 className="font-display text-4xl font-semibold leading-tight text-brand-charcoal sm:text-5xl">
+                Stories from the foothills, curated with heart.
+              </h1>
+              <p className="text-lg text-brand-charcoal/80">
+                The Red Clay Field Guide celebrates the people and places that make our corner of the South unforgettable—from
+                farm suppers and trail adventures to porch concerts and hidden makers.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-4">
               <a
-                className="rounded-full bg-brand-red px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-brand-red/25 transition hover:-translate-y-0.5 hover:shadow-xl"
-                href="#"
+                className="rounded-full bg-brand-red px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-brand-red/25 transition hover:-translate-y-0.5 hover:shadow-xl"
+                href="#featured"
               >
                 Read the latest
               </a>
-              <a className="text-sm font-semibold uppercase tracking-wide text-brand-charcoal/70 hover:text-brand-charcoal" href="#">
-                View categories
+              <a
+                className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-charcoal/70 transition hover:text-brand-charcoal"
+                href="#newsletter"
+              >
+                Join the newsletter
               </a>
             </div>
+            <ul className="grid gap-3 text-sm text-brand-charcoal/70 sm:grid-cols-2">
+              {heroHighlights.map((highlight) => (
+                <li key={highlight} className="flex items-start gap-3">
+                  <span aria-hidden="true" className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-brand-red" />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
           </motion.div>
           <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
+            initial={{ opacity: 0, scale: 0.94 }}
             animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.8, ease: 'easeOut', delay: 0.1 }}
+            transition={{ duration: 0.75, ease: 'easeOut', delay: 0.1 }}
             className="w-full max-w-md overflow-hidden rounded-3xl border border-brand-charcoal/10 bg-white shadow-xl"
           >
             <div className="bg-gradient-to-br from-brand-red/90 to-brand-charcoal/90 p-6 text-white">
-              <h2 className="font-display text-2xl font-semibold">Coming soon</h2>
+              <h2 className="font-display text-2xl font-semibold">Now featuring stories across four beats</h2>
               <p className="mt-2 text-sm text-white/80">
-                This placeholder hero shows the design direction while we build out the data-driven homepage.
+                Dive into food & drink, trails & travel, arts & entertainment, and trusted local services while we finish
+                connecting the CMS.
               </p>
             </div>
             <div className="space-y-6 p-6 text-sm text-brand-charcoal/80">
               <p>
-                The frontend is powered by React, Vite, Tailwind CSS, and Framer Motion inside a PNPM workspace.
+                The frontend is powered by React, Vite, Tailwind CSS, and Framer Motion inside a PNPM workspace. Each section below
+                is wired to render curated data while the API is under construction.
               </p>
               <p>
-                As API endpoints and CMS content come online, this hero will display featured stories and surface the latest
-                guides curated from the database.
+                As endpoints go live, these modules will swap to dynamic content—ready for scheduling, sponsorships, and editorial
+                workflows defined in the implementation plan.
               </p>
             </div>
           </motion.div>
         </section>
+        <FeaturedStories posts={featuredStories} />
+        <SponsorSpotlight sponsor={sponsorSpotlight} />
+        {homepageSections.map((section, index) => (
+          <CategoryShowcase key={section.category.slug} category={section.category} posts={section.posts} index={index} />
+        ))}
+        <div id="newsletter">
+          <NewsletterSignup />
+        </div>
       </main>
       <footer className="border-t border-brand-charcoal/10 bg-white/80 py-8">
-        <div className="mx-auto flex max-w-6xl flex-col items-start gap-2 px-4 text-sm text-brand-charcoal/70 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto flex max-w-6xl flex-col items-start gap-2 px-4 text-xs font-semibold uppercase tracking-[0.3em] text-brand-charcoal/60 sm:flex-row sm:items-center sm:justify-between">
           <span>&copy; {new Date().getFullYear()} Red Clay Field Guide. All rights reserved.</span>
           <div className="flex gap-4">
-            <a className="transition hover:text-brand-red" href="#">
+            <a className="transition hover:text-brand-red" href="#about">
               About
             </a>
-            <a className="transition hover:text-brand-red" href="#">
+            <a className="transition hover:text-brand-red" href="#contact">
               Contact
             </a>
-            <a className="transition hover:text-brand-red" href="#">
+            <a className="transition hover:text-brand-red" href="#advertise">
               Advertise
             </a>
           </div>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,102 @@
+import { motion } from 'framer-motion';
+import type { Post } from '../lib/homepageData';
+import { categoryLookup } from '../lib/homepageData';
+
+const fadeIn = {
+  hidden: { opacity: 0, y: 24 },
+  visible: { opacity: 1, y: 0 }
+};
+
+type PostCardVariant = 'standard' | 'featured';
+
+interface PostCardProps {
+  post: Post;
+  variant?: PostCardVariant;
+  showExcerpt?: boolean;
+}
+
+const formatDate = (date: string) =>
+  new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric'
+  });
+
+const PostCard = ({ post, variant = 'standard', showExcerpt = true }: PostCardProps) => {
+  if (variant === 'featured') {
+    return (
+      <motion.article
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.3 }}
+        variants={fadeIn}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className="group relative overflow-hidden rounded-3xl bg-brand-charcoal text-white shadow-2xl"
+      >
+        <div
+          className="absolute inset-0 bg-cover bg-center transition-transform duration-700 group-hover:scale-105"
+          style={{ backgroundImage: `url(${post.imageUrl})` }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-brand-charcoal via-brand-charcoal/80 to-transparent" />
+        <div className="relative flex h-full min-h-[420px] flex-col justify-end gap-5 p-10">
+          <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/70">
+            <span>{categoryLookup[post.category]?.name ?? post.category}</span>
+            <span aria-hidden="true" className="h-px w-6 bg-white/40" />
+            <span>
+              {formatDate(post.publishedAt)} • {post.readTimeMinutes} min read
+            </span>
+          </div>
+          <div className="space-y-4">
+            <h3 className="font-display text-3xl font-semibold leading-tight sm:text-4xl">{post.title}</h3>
+            <p className="max-w-2xl text-base text-white/80">{post.excerpt}</p>
+          </div>
+          <div className="flex items-center gap-4 text-sm font-semibold uppercase tracking-[0.2em]">
+            <span className="rounded-full bg-white/15 px-4 py-1">{post.location}</span>
+            <span className="text-white/80">By {post.author}</span>
+          </div>
+        </div>
+      </motion.article>
+    );
+  }
+
+  return (
+    <motion.article
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.4 }}
+      variants={fadeIn}
+      transition={{ duration: 0.55, ease: 'easeOut' }}
+      className="group flex h-full flex-col overflow-hidden rounded-2xl border border-brand-charcoal/10 bg-white shadow-lg transition hover:-translate-y-1 hover:shadow-xl"
+    >
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <img
+          alt={post.imageAlt}
+          src={post.imageUrl}
+          className="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+          loading="lazy"
+        />
+        <div className="absolute inset-0 bg-gradient-to-tr from-brand-charcoal/20 via-transparent to-transparent" />
+      </div>
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-brand-charcoal/60">
+          <span>{categoryLookup[post.category]?.name ?? post.category}</span>
+          <span aria-hidden="true" className="h-px w-6 bg-brand-charcoal/10" />
+          <span>
+            {formatDate(post.publishedAt)} • {post.readTimeMinutes} min
+          </span>
+        </div>
+        <div className="space-y-3">
+          <h3 className="font-display text-xl font-semibold text-brand-charcoal transition group-hover:text-brand-red">
+            {post.title}
+          </h3>
+          {showExcerpt && <p className="text-sm leading-relaxed text-brand-charcoal/80">{post.excerpt}</p>}
+        </div>
+        <div className="mt-auto flex items-center justify-between text-xs font-semibold uppercase tracking-[0.2em] text-brand-charcoal/60">
+          <span>{post.location}</span>
+          <span>By {post.author}</span>
+        </div>
+      </div>
+    </motion.article>
+  );
+};
+
+export default PostCard;

--- a/src/features/home/CategoryShowcase.tsx
+++ b/src/features/home/CategoryShowcase.tsx
@@ -1,0 +1,52 @@
+import { motion } from 'framer-motion';
+import PostCard from '../../components/PostCard';
+import type { Category, Post } from '../../lib/homepageData';
+
+interface CategoryShowcaseProps {
+  category: Category;
+  posts: Post[];
+  index: number;
+}
+
+const headingVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 }
+};
+
+const CategoryShowcase = ({ category, posts, index }: CategoryShowcaseProps) => (
+  <section
+    aria-labelledby={`${category.slug}-heading`}
+    className="mx-auto max-w-6xl px-4 pb-20"
+    id={category.slug}
+  >
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={headingVariants}
+      transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.05 }}
+      className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-charcoal/60">{category.name}</p>
+        <h3 id={`${category.slug}-heading`} className="font-display text-2xl font-semibold text-brand-charcoal sm:text-3xl">
+          {category.tagline}
+        </h3>
+      </div>
+      <a
+        className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-brand-charcoal/60 transition hover:text-brand-red"
+        href={`#${category.slug}`}
+      >
+        View more {category.name.toLowerCase()}
+        <span aria-hidden="true">→</span>
+      </a>
+    </motion.div>
+    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </div>
+  </section>
+);
+
+export default CategoryShowcase;

--- a/src/features/home/FeaturedStories.tsx
+++ b/src/features/home/FeaturedStories.tsx
@@ -1,0 +1,64 @@
+import { motion } from 'framer-motion';
+import PostCard from '../../components/PostCard';
+import type { Post } from '../../lib/homepageData';
+
+interface FeaturedStoriesProps {
+  posts: Post[];
+}
+
+const sectionVariants = {
+  hidden: { opacity: 0, y: 32 },
+  visible: { opacity: 1, y: 0 }
+};
+
+const FeaturedStories = ({ posts }: FeaturedStoriesProps) => {
+  if (!posts.length) {
+    return null;
+  }
+
+  const [primary, ...secondary] = posts;
+
+  const hasSecondary = secondary.length > 0;
+
+  return (
+    <section aria-labelledby="featured-heading" className="mx-auto max-w-6xl px-4 pb-20" id="featured">
+      <motion.div
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.3 }}
+        variants={sectionVariants}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className="mb-12 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between"
+      >
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-charcoal/60">Featured this week</p>
+          <h2 id="featured-heading" className="font-display text-3xl font-semibold text-brand-charcoal sm:text-4xl">
+            Fresh from the foothills
+          </h2>
+          <p className="max-w-xl text-base text-brand-charcoal/70">
+            A first look at the seasonal stories, itineraries, and guides we're most excited to explore right now.
+          </p>
+        </div>
+        <a
+          className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-brand-charcoal/70 transition hover:text-brand-red"
+          href="#stories"
+        >
+          Browse all stories
+          <span aria-hidden="true">→</span>
+        </a>
+      </motion.div>
+      <div className={`grid gap-6 ${hasSecondary ? 'lg:grid-cols-[1.4fr,1fr]' : ''}`}>
+        <PostCard post={primary} variant="featured" />
+        {hasSecondary && (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-1">
+            {secondary.map((post) => (
+              <PostCard key={post.id} post={post} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default FeaturedStories;

--- a/src/features/home/NewsletterSignup.tsx
+++ b/src/features/home/NewsletterSignup.tsx
@@ -1,0 +1,49 @@
+import { motion } from 'framer-motion';
+import { newsletterContent } from '../../lib/homepageData';
+
+const NewsletterSignup = () => (
+  <section aria-labelledby="newsletter-heading" className="mx-auto max-w-5xl px-4 pb-24">
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+      className="relative overflow-hidden rounded-3xl border border-brand-charcoal/10 bg-white/90 p-10 shadow-2xl backdrop-blur"
+    >
+      <div className="absolute -top-24 right-12 hidden h-56 w-56 rounded-full bg-brand-red/10 blur-3xl sm:block" aria-hidden />
+      <div className="absolute -bottom-16 left-8 hidden h-40 w-40 rounded-full bg-brand-red/20 blur-3xl sm:block" aria-hidden />
+      <div className="relative space-y-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-red">{newsletterContent.eyebrow}</p>
+        <h2 id="newsletter-heading" className="font-display text-3xl font-semibold text-brand-charcoal sm:text-4xl">
+          {newsletterContent.headline}
+        </h2>
+        <p className="max-w-2xl text-base leading-relaxed text-brand-charcoal/80">{newsletterContent.description}</p>
+        <form className="mt-8 flex flex-col gap-4 sm:flex-row" noValidate>
+          <label className="sr-only" htmlFor="newsletter-email">
+            Email address
+          </label>
+          <input
+            className="w-full rounded-full border border-brand-charcoal/15 bg-white px-6 py-3 text-sm text-brand-charcoal shadow-inner shadow-brand-charcoal/5 focus:border-brand-red focus:outline-none focus:ring-2 focus:ring-brand-red/30"
+            id="newsletter-email"
+            name="email"
+            placeholder="you@example.com"
+            type="email"
+            autoComplete="email"
+            required
+          />
+          <button
+            className="inline-flex items-center justify-center rounded-full bg-brand-red px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-brand-red/30 transition hover:-translate-y-0.5 hover:shadow-xl"
+            type="submit"
+          >
+            Join the list
+          </button>
+        </form>
+        <p className="text-xs uppercase tracking-[0.3em] text-brand-charcoal/50">
+          No spam. Unsubscribe anytime.
+        </p>
+      </div>
+    </motion.div>
+  </section>
+);
+
+export default NewsletterSignup;

--- a/src/features/home/SponsorSpotlight.tsx
+++ b/src/features/home/SponsorSpotlight.tsx
@@ -1,0 +1,47 @@
+import { motion } from 'framer-motion';
+import type { SponsorPlacement } from '../../lib/homepageData';
+
+interface SponsorSpotlightProps {
+  sponsor: SponsorPlacement;
+}
+
+const SponsorSpotlight = ({ sponsor }: SponsorSpotlightProps) => (
+  <section aria-labelledby="sponsor-heading" className="mx-auto max-w-6xl px-4 pb-20">
+    <motion.div
+      initial={{ opacity: 0, y: 32 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+      className="overflow-hidden rounded-3xl border border-brand-charcoal/10 bg-gradient-to-br from-brand-charcoal via-brand-charcoal/95 to-brand-red/90 text-white shadow-2xl"
+    >
+      <div className="flex flex-col gap-8 p-8 sm:flex-row sm:items-center sm:p-10 lg:gap-12">
+        <div className="relative h-48 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-white/10 sm:h-56 sm:w-56">
+          <img
+            alt={sponsor.imageAlt}
+            src={sponsor.imageUrl}
+            className="h-full w-full object-cover opacity-90"
+            loading="lazy"
+          />
+        </div>
+        <div className="space-y-6">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">Sponsor spotlight</p>
+            <h2 id="sponsor-heading" className="font-display text-3xl font-semibold sm:text-4xl">
+              {sponsor.name}
+            </h2>
+            <p className="max-w-2xl text-sm leading-relaxed text-white/80">{sponsor.description}</p>
+          </div>
+          <a
+            className="inline-flex items-center gap-3 rounded-full bg-white px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-brand-charcoal transition hover:bg-brand-cream"
+            href={sponsor.ctaHref}
+          >
+            {sponsor.ctaLabel}
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+    </motion.div>
+  </section>
+);
+
+export default SponsorSpotlight;

--- a/src/lib/homepageData.ts
+++ b/src/lib/homepageData.ts
@@ -1,0 +1,368 @@
+export type CategorySlug = 'food' | 'travel' | 'entertainment' | 'services';
+
+export interface Category {
+  slug: CategorySlug;
+  name: string;
+  tagline: string;
+}
+
+export interface Post {
+  id: string;
+  title: string;
+  slug: string;
+  category: CategorySlug;
+  excerpt: string;
+  imageUrl: string;
+  imageAlt: string;
+  publishedAt: string;
+  readTimeMinutes: number;
+  author: string;
+  location: string;
+  tags: string[];
+  isFeatured?: boolean;
+}
+
+export interface SponsorPlacement {
+  name: string;
+  description: string;
+  imageUrl: string;
+  imageAlt: string;
+  ctaLabel: string;
+  ctaHref: string;
+}
+
+export const categories: Category[] = [
+  {
+    slug: 'food',
+    name: 'Food & Drink',
+    tagline: 'Restaurants, farms, and makers fueling the foothills.'
+  },
+  {
+    slug: 'travel',
+    name: 'Trails & Travel',
+    tagline: 'Scenic drives, waterfall hikes, and cozy cabins to book next.'
+  },
+  {
+    slug: 'entertainment',
+    name: 'Arts & Entertainment',
+    tagline: 'Live music, gallery openings, festivals, and small town events.'
+  },
+  {
+    slug: 'services',
+    name: 'Local Services',
+    tagline: 'Trusted guides, outfitters, and pros keeping our community moving.'
+  }
+];
+
+export const categoryLookup = categories.reduce<Record<CategorySlug, Category>>((acc, category) => {
+  acc[category.slug] = category;
+  return acc;
+}, {} as Record<CategorySlug, Category>);
+
+const posts: Post[] = [
+  {
+    id: 'supper-club-fall',
+    title: 'Harvest Supper Club: Farmhouse Flavors for Fall',
+    slug: 'harvest-supper-club-farmhouse-flavors',
+    category: 'food',
+    excerpt:
+      'Chef Denise Holloway showcases heritage grains, orchard produce, and Appalachian cheeses in a candlelit supper under the stars.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1473093295043-cdd812d0e601?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A candlelit farm table set for an autumn dinner with seasonal dishes.',
+    publishedAt: '2024-10-02',
+    readTimeMinutes: 6,
+    author: 'Shane Michel',
+    location: 'Clarkesville, GA',
+    tags: ['seasonal', 'chef'],
+    isFeatured: true
+  },
+  {
+    id: 'cider-trail',
+    title: 'North Georgia Cider Trail: Five Stops to Sip This Weekend',
+    slug: 'north-georgia-cider-trail-weekend',
+    category: 'food',
+    excerpt:
+      'From small-batch pear blends to tart apple spice, explore a self-guided tasting tour across orchards in Rabun and White counties.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A row of hard cider glasses on a wooden bar with autumn leaves in the background.',
+    publishedAt: '2024-09-24',
+    readTimeMinutes: 5,
+    author: 'Vicki Michel',
+    location: 'Tiger, GA',
+    tags: ['itinerary', 'beverage'],
+    isFeatured: true
+  },
+  {
+    id: 'smoky-mountain-lineup',
+    title: '7 Live Music Sets to Catch Before the Leaves Change',
+    slug: 'live-music-sets-leaf-season',
+    category: 'entertainment',
+    excerpt:
+      'From bluegrass brunches to rooftop jazz jams, here are the can’t-miss performances lighting up the foothills this month.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1472653431158-6364773b2a56?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A guitarist performing on stage with warm lights reflecting on the audience.',
+    publishedAt: '2024-09-28',
+    readTimeMinutes: 4,
+    author: 'Shane Michel',
+    location: 'Gainesville, GA',
+    tags: ['music', 'events'],
+    isFeatured: true
+  },
+  {
+    id: 'mountain-biking',
+    title: 'Singletrack Secrets: Flowy Fall Rides Near Yonah',
+    slug: 'singletrack-secrets-fall-rides',
+    category: 'travel',
+    excerpt:
+      'We mapped three intermediate-friendly routes with sweeping views, creek crossings, and post-ride tacos nearby.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1470246973918-29a93221c455?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'Mountain bikers riding through a forest trail covered in fall leaves.',
+    publishedAt: '2024-09-18',
+    readTimeMinutes: 7,
+    author: 'Vicki Michel',
+    location: 'Yonah Mountain, GA',
+    tags: ['outdoors', 'cycling']
+  },
+  {
+    id: 'leatherwood-market',
+    title: 'Leatherwood Market: Meet the Makers Reviving Folk Crafts',
+    slug: 'leatherwood-market-makers',
+    category: 'entertainment',
+    excerpt:
+      'Quilt artist Aaliyah Brooks and potter Miguel Herrera share how the market is passing traditions to the next generation.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1470309864661-68328b2cd0a5?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'An artisan pottery display at an outdoor market.',
+    publishedAt: '2024-09-10',
+    readTimeMinutes: 6,
+    author: 'Shane Michel',
+    location: 'Dahlonega, GA',
+    tags: ['makers', 'community']
+  },
+  {
+    id: 'moonrise-cabin',
+    title: 'Moonrise Cabin: A Weekend Retreat Above Lake Burton',
+    slug: 'moonrise-cabin-weekend-retreat',
+    category: 'travel',
+    excerpt:
+      'Design-forward interiors, a cedar sauna, and a chef’s kitchen make this hideaway perfect for a slow, restorative long weekend.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A modern cabin with floor-to-ceiling windows overlooking a forested lake.',
+    publishedAt: '2024-09-05',
+    readTimeMinutes: 8,
+    author: 'Vicki Michel',
+    location: 'Lake Burton, GA',
+    tags: ['stay', 'design']
+  },
+  {
+    id: 'service-guide-trail',
+    title: 'Trailside Tune-Ups: Mechanics Keeping Riders Rolling',
+    slug: 'trailside-tune-ups',
+    category: 'services',
+    excerpt:
+      'Mobile mechanics and gear co-ops share how they keep locals and visitors ready for any mountain adventure.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1448387473223-5c37445527e7?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A bicycle mechanic working on a mountain bike outdoors.',
+    publishedAt: '2024-08-27',
+    readTimeMinutes: 5,
+    author: 'Shane Michel',
+    location: 'Helen, GA',
+    tags: ['service', 'outdoors']
+  },
+  {
+    id: 'farmers-market-finds',
+    title: 'What to Buy at the October Clarkesville Farmers Market',
+    slug: 'october-farmers-market-finds',
+    category: 'food',
+    excerpt:
+      'Sweet potato hand pies, muscadine jam, and cold brew from a new micro-roaster lead our picks this month.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1542838686-73e80f1a5db0?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'Fresh produce and baked goods at a fall farmers market booth.',
+    publishedAt: '2024-09-30',
+    readTimeMinutes: 4,
+    author: 'Vicki Michel',
+    location: 'Clarkesville, GA',
+    tags: ['market', 'seasonal']
+  },
+  {
+    id: 'ridge-wildflower-guide',
+    title: 'Where to Spot the Last Wildflowers Along Panther Creek',
+    slug: 'panther-creek-wildflowers',
+    category: 'travel',
+    excerpt:
+      'Our ranger friends share the exact overlooks where the final bursts of color are still holding strong.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'Wildflowers blooming beside a rushing creek in the mountains.',
+    publishedAt: '2024-09-14',
+    readTimeMinutes: 3,
+    author: 'Shane Michel',
+    location: 'Tallulah Gorge, GA',
+    tags: ['wildflowers', 'hiking']
+  },
+  {
+    id: 'storytelling-festival',
+    title: 'Storytelling Festival Returns With Porch Concerts & Poetry',
+    slug: 'storytelling-festival-returns',
+    category: 'entertainment',
+    excerpt:
+      'Two days of porch concerts, open-mic poetry, and kid-friendly workshops fill the historic square with sound.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1518895949257-7621c3c786d4?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'People gathered outdoors listening to a storyteller with string lights overhead.',
+    publishedAt: '2024-09-12',
+    readTimeMinutes: 5,
+    author: 'Vicki Michel',
+    location: 'Clarkesville, GA',
+    tags: ['festival', 'family']
+  },
+  {
+    id: 'barista-profile',
+    title: 'Behind the Bar: Kennesaw’s Award-Winning Latte Artist',
+    slug: 'kennesaw-latte-artist',
+    category: 'food',
+    excerpt:
+      'Latte art champion Maria Sosa shares her morning routine, favorite beans, and what makes a perfect pour.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A barista pouring latte art into a cup of coffee.',
+    publishedAt: '2024-08-22',
+    readTimeMinutes: 6,
+    author: 'Shane Michel',
+    location: 'Kennesaw, GA',
+    tags: ['coffee', 'profile']
+  },
+  {
+    id: 'lanier-paddle-guide',
+    title: 'Sunrise Paddle Guide: Launch Points Around Lake Lanier',
+    slug: 'sunrise-paddle-guide-lanier',
+    category: 'travel',
+    excerpt:
+      'Beat the heat with sunrise routes, breakfast stops, and insider tips for navigating quiet coves.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80&sat=-15',
+    imageAlt: 'Kayakers paddling across a calm lake at sunrise.',
+    publishedAt: '2024-08-18',
+    readTimeMinutes: 4,
+    author: 'Vicki Michel',
+    location: 'Lake Lanier, GA',
+    tags: ['water', 'guide']
+  },
+  {
+    id: 'stagecoach-theatre',
+    title: 'Stagecoach Theatre Debuts Renovated Historic Playhouse',
+    slug: 'stagecoach-theatre-renovation',
+    category: 'entertainment',
+    excerpt:
+      'Take a peek inside the lovingly restored playhouse ahead of its grand opening performance schedule.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1515168833906-d1c4eddfba53?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'Interior of a historic theatre with red velvet seats and ornate ceiling.',
+    publishedAt: '2024-08-15',
+    readTimeMinutes: 7,
+    author: 'Shane Michel',
+    location: 'Toccoa, GA',
+    tags: ['theatre', 'heritage']
+  },
+  {
+    id: 'service-guide-event-planners',
+    title: 'Event Planners Bridging Atlanta & the Mountains',
+    slug: 'event-planners-foothills',
+    category: 'services',
+    excerpt:
+      'Boutique planners share logistics tips for weddings, corporate retreats, and creative residencies in the region.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'An outdoor wedding reception with hanging lights and elegantly set tables.',
+    publishedAt: '2024-08-12',
+    readTimeMinutes: 6,
+    author: 'Vicki Michel',
+    location: 'Cleveland, GA',
+    tags: ['business', 'planning']
+  },
+  {
+    id: 'gear-library',
+    title: 'Borrow Before You Buy: Meet the Regional Gear Library',
+    slug: 'regional-gear-library',
+    category: 'services',
+    excerpt:
+      'Check out backpacking kits, film cameras, and festival gear thanks to a new cooperative lending program.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'Shelves filled with outdoor gear like backpacks and lanterns.',
+    publishedAt: '2024-08-03',
+    readTimeMinutes: 5,
+    author: 'Shane Michel',
+    location: 'Athens, GA',
+    tags: ['community', 'resources']
+  },
+  {
+    id: 'supper-series',
+    title: 'Sunday Supper Series Heads to the Orchard',
+    slug: 'sunday-supper-series-orchard',
+    category: 'food',
+    excerpt:
+      'Tickets just dropped for this chef-collab dinner featuring heirloom apples and live fire cooking.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1600&q=80&sat=-20',
+    imageAlt: 'A farm dinner with shared plates and seasonal dishes.',
+    publishedAt: '2024-07-29',
+    readTimeMinutes: 3,
+    author: 'Vicki Michel',
+    location: 'Ellijay, GA',
+    tags: ['events', 'food']
+  },
+  {
+    id: 'service-guide-gardeners',
+    title: 'Master Gardeners Cultivating Pollinator Corridors',
+    slug: 'master-gardeners-pollinator-corridors',
+    category: 'services',
+    excerpt:
+      'Meet the volunteers transforming vacant lots into teaching gardens lined with native blooms.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1441118963152-fb0bc406e9b2?auto=format&fit=crop&w=1600&q=80',
+    imageAlt: 'A gardener planting flowers in a community garden.',
+    publishedAt: '2024-07-20',
+    readTimeMinutes: 4,
+    author: 'Shane Michel',
+    location: 'Cornelia, GA',
+    tags: ['gardening', 'community']
+  }
+];
+
+export const featuredStories = posts.filter((post) => post.isFeatured);
+
+export const postsByCategory = categories.reduce<Record<CategorySlug, Post[]>>((acc, category) => {
+  acc[category.slug] = posts.filter((post) => post.category === category.slug).slice(0, 4);
+  return acc;
+}, {} as Record<CategorySlug, Post[]>);
+
+export const homepageSections = categories.map((category) => ({
+  category,
+  posts: postsByCategory[category.slug]
+}));
+
+export const sponsorSpotlight: SponsorPlacement = {
+  name: 'Soque River Outfitters',
+  description:
+    'Guided fly fishing floats, casting workshops, and curated gear for anglers discovering the Soque River headwaters.',
+  imageUrl:
+    'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80&sat=-25',
+  imageAlt: 'An angler casting a line in a misty river at sunrise.',
+  ctaLabel: 'Book a float trip',
+  ctaHref: '#'
+};
+
+export const newsletterContent = {
+  eyebrow: 'Weekend Dispatch',
+  headline: 'Get the Red Clay itinerary before anyone else.',
+  description:
+    'Every Thursday morning we send a quick guide with new stories, events, and sponsor perks to help you plan your weekend in Northeast Georgia.'
+};

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -10,6 +10,10 @@ body {
   font-family: theme('fontFamily.sans');
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 a {
   text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- add structured homepage data for categories, posts, sponsor, and newsletter content
- build featured stories, category showcase, sponsor spotlight, and newsletter signup components powered by mock data
- refresh the app shell with sticky navigation, hero updates, smooth scrolling, and hosted fonts, and ignore TypeScript build artifacts

## Testing
- pnpm install *(fails: registry.npmjs.org returns 403 in container)*
- pnpm build *(fails: missing vite/client and node types because dependencies are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cabe39ac1c8332ad67781f02d59403